### PR TITLE
Gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-__pycache__/
+**/__pycache__/
 .vscode/
+venv/
+.venv/
 test.py
 search_history.json
 api_cache.sqlite


### PR DESCRIPTION
- Apply `__pycache__` rule to all folders, including sub-folders.
- Prevent excessive file tracking when the project is checked out for standalone development (where the repo is in its own folder outside of a WebUI installation) by ignoring `venv` (and `.venv`) folders.