### PR TITLE
Fileinfo improvements

### DIFF
--- a/scripts/civsfz_api.py
+++ b/scripts/civsfz_api.py
@@ -893,12 +893,12 @@ class CivitaiModels(APIInformation):
 
     def getUrlByNameMetadata(self, model_name_metadata=''):
         if self.modelIndex is None:
-            # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select model first. {model_filename}' + Style.RESET_ALL )
+            # print(Fore.LIGHTYELLOW_EX + f'getUrlByNameMetadata: Select model first. {model_name_metadata}' + Style.RESET_ALL )
             return
         if self.versionIndex is None:
-            # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select version first. {model_filename}' + Style.RESET_ALL )
+            # print(Fore.LIGHTYELLOW_EX + f'getUrlByNameMetadata: Select version first. {model_name_metadata}' + Style.RESET_ALL )
             return
-        # print(Fore.LIGHTYELLOW_EX + f'File name . {model_filename}' + Style.RESET_ALL )
+        # print(Fore.LIGHTYELLOW_EX + f'File name . {model_name_metadata}' + Style.RESET_ALL )
         item = self.jsonData['items'][self.modelIndex]
         version = item['modelVersions'][self.versionIndex]
         dl_url = None
@@ -909,12 +909,12 @@ class CivitaiModels(APIInformation):
         return dl_url
     def getHashByNameMetadata(self, model_name_metadata=''):
         if self.modelIndex is None:
-            # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select model first. {model_filename}' + Style.RESET_ALL )
+            # print(Fore.LIGHTYELLOW_EX + f'getHashByNameMetadata: Select model first. {model_name_metadata}' + Style.RESET_ALL )
             return
         if self.versionIndex is None:
-            # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select version first. {model_filename}' + Style.RESET_ALL )
+            # print(Fore.LIGHTYELLOW_EX + f'getHashByNameMetadata: Select version first. {model_name_metadata}' + Style.RESET_ALL )
             return
-        # print(Fore.LIGHTYELLOW_EX + f'File name . {model_filename}' + Style.RESET_ALL )
+        # print(Fore.LIGHTYELLOW_EX + f'File name . {model_name_metadata}' + Style.RESET_ALL )
         item = self.jsonData['items'][self.modelIndex]
         version = item['modelVersions'][self.versionIndex]
         sha256 = ""

--- a/scripts/civsfz_api.py
+++ b/scripts/civsfz_api.py
@@ -891,7 +891,7 @@ class CivitaiModels(APIInformation):
         self.setModelVersionInfo(modelInfo)
         return modelInfo
 
-    def getUrlByName(self, model_filename=None):
+    def getUrlByNameMetadata(self, model_name_metadata=''):
         if self.modelIndex is None:
             # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select model first. {model_filename}' + Style.RESET_ALL )
             return
@@ -903,10 +903,11 @@ class CivitaiModels(APIInformation):
         version = item['modelVersions'][self.versionIndex]
         dl_url = None
         for file in version['files']:
-            if file['name'] == model_filename:
+            name, *metadata = model_name_metadata.split('|')
+            if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)):
                 dl_url = file['downloadUrl']
         return dl_url
-    def getHashByName(self, model_filename=None):
+    def getHashByNameMetadata(self, model_name_metadata=''):
         if self.modelIndex is None:
             # print(Fore.LIGHTYELLOW_EX + f'getUrlByName: Select model first. {model_filename}' + Style.RESET_ALL )
             return
@@ -919,7 +920,8 @@ class CivitaiModels(APIInformation):
         sha256 = ""
         for file in version['files']:
             # print_lc(f'{file["hashes"]=}')
-            if file['name'] == model_filename and 'SHA256' in file['hashes']:
+            name, *metadata = model_name_metadata.split('|')
+            if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)) and 'SHA256' in file['hashes']:
                 sha256 = file['hashes']['SHA256']
         return sha256
 

--- a/scripts/civsfz_api.py
+++ b/scripts/civsfz_api.py
@@ -903,7 +903,7 @@ class CivitaiModels(APIInformation):
         version = item['modelVersions'][self.versionIndex]
         dl_url = None
         for file in version['files']:
-            name, *metadata = model_name_metadata.split('|')
+            name, *metadata = model_name_metadata.split("|")
             if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)):
                 dl_url = file['downloadUrl']
         return dl_url
@@ -920,7 +920,7 @@ class CivitaiModels(APIInformation):
         sha256 = ""
         for file in version['files']:
             # print_lc(f'{file["hashes"]=}')
-            name, *metadata = model_name_metadata.split('|')
+            name, *metadata = model_name_metadata.split("|")
             if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)) and 'SHA256' in file['hashes']:
                 sha256 = file['hashes']['SHA256']
         return sha256

--- a/scripts/civsfz_api.py
+++ b/scripts/civsfz_api.py
@@ -903,7 +903,7 @@ class CivitaiModels(APIInformation):
         version = item['modelVersions'][self.versionIndex]
         dl_url = None
         for file in version['files']:
-            name, *metadata = model_name_metadata.split("|")
+            name, *metadata = model_name_metadata.split(" | ")
             if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)):
                 dl_url = file['downloadUrl']
         return dl_url
@@ -920,7 +920,7 @@ class CivitaiModels(APIInformation):
         sha256 = ""
         for file in version['files']:
             # print_lc(f'{file["hashes"]=}')
-            name, *metadata = model_name_metadata.split("|")
+            name, *metadata = model_name_metadata.split(" | ")
             if file['name'] == name and set(file['metadata'].values()).issuperset(set(metadata)) and 'SHA256' in file['hashes']:
                 sha256 = file['hashes']['SHA256']
         return sha256

--- a/scripts/civsfz_ui.py
+++ b/scripts/civsfz_ui.py
@@ -932,7 +932,7 @@ class Components():
                         #gr.Textbox.update(value=", ".join(modelInfo["trainedWords"])),
                         drpdwn,
                         gr.Textbox.update(value=modelInfo["baseModel"]),
-                        gr.Textbox.update(value=path),
+                        gr.Textbox.update(value=str(path)),
                         gr.Textbox.update(value=txtEarlyAccess),
                         grTxtSaveFilename,
                         grHtmlModelName,

--- a/scripts/civsfz_ui.py
+++ b/scripts/civsfz_ui.py
@@ -905,20 +905,20 @@ class Components():
                         grHtmlModelName = gr.HTML.update(value="")
                     else:
                         first_entry = modelInfo["modelVersions"][0]["files"][0]
-                        file_metadata = "|".join([first_entry["name"]] + [md for md in first_entry["metadata"].values() if md is not None])
+                        file_metadata = " | ".join([first_entry["name"]] + [md for md in first_entry["metadata"].values() if md is not None])
                         for f in modelInfo["modelVersions"][0]["files"]:
                             if 'primary' in f:
                                 if f['primary']:
-                                    file_metadata = "|".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
+                                    file_metadata = " | ".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
                                     break
                         drpdwn = gr.Dropdown.update(
                             choices=[
-                                "|".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
+                                " | ".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
                                 for f in modelInfo["modelVersions"][0]["files"]
                             ],
                             value=file_metadata,
                         )
-                        grTxtSaveFilename = gr.Textbox.update(value=file_metadata.split("|", 1)[0])
+                        grTxtSaveFilename = gr.Textbox.update(value=file_metadata.split(" | ", 1)[0])
                         grHtmlModelName = gr.HTML.update(
                             value=self.Civitai.modelNameTitleHtml(
                                 self.Civitai.getSelectedModelName(),
@@ -995,7 +995,7 @@ class Components():
                     gr.Button.update(interactive=True if selection else False), # '' is evaluated as False
                     gr.Button.update(interactive=True if selection else False),
                     gr.Textbox.update(value=""),
-                    gr.Textbox.update(value=selection.split("|", 1)[0]),
+                    gr.Textbox.update(value=selection.split(" | ", 1)[0]),
                 )
 
             def checkEarlyAccess(grTxtEarlyAccess):

--- a/scripts/civsfz_ui.py
+++ b/scripts/civsfz_ui.py
@@ -898,9 +898,11 @@ class Components():
                                                 self.Civitai.getSelectedVersionName()
                                             )
                     modelInfo = self.Civitai.makeModelInfo2(nsfwLevel=sum(grChkbxgrpLevel))
+                    txtEarlyAccess = self.Civitai.getSelectedVersionEarlyAccessDeadline()
                     if modelInfo["modelVersions"][0]["files"] == []:
                         drpdwn =  gr.Dropdown.update(choices=[], value="")
                         grTxtSaveFilename = gr.Textbox.update(value="")
+                        grHtmlModelName = gr.HTML.update(value="")
                     else:
                         filename = modelInfo["modelVersions"][0]["files"][0]["name"]
                         for f in modelInfo["modelVersions"][0]["files"]:
@@ -916,7 +918,6 @@ class Components():
                             value=filename,
                         )
                         grTxtSaveFilename = gr.Textbox.update(value=filename)
-                        txtEarlyAccess = self.Civitai.getSelectedVersionEarlyAccessDeadline()
                         grHtmlModelName = gr.HTML.update(
                             value=self.Civitai.modelNameTitleHtml(
                                 self.Civitai.getSelectedModelName(),

--- a/scripts/civsfz_ui.py
+++ b/scripts/civsfz_ui.py
@@ -904,20 +904,21 @@ class Components():
                         grTxtSaveFilename = gr.Textbox.update(value="")
                         grHtmlModelName = gr.HTML.update(value="")
                     else:
-                        filename = modelInfo["modelVersions"][0]["files"][0]["name"]
+                        first_entry = modelInfo["modelVersions"][0]["files"][0]
+                        file_metadata = "|".join([first_entry["name"]] + [md for md in first_entry["metadata"].values() if md is not None])
                         for f in modelInfo["modelVersions"][0]["files"]:
                             if 'primary' in f:
                                 if f['primary']:
-                                    filename = f["name"]
+                                    file_metadata = "|".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
                                     break
                         drpdwn = gr.Dropdown.update(
                             choices=[
-                                f["name"]
+                                "|".join([f["name"]] + [md for md in f["metadata"].values() if md is not None])
                                 for f in modelInfo["modelVersions"][0]["files"]
                             ],
-                            value=filename,
+                            value=file_metadata,
                         )
-                        grTxtSaveFilename = gr.Textbox.update(value=filename)
+                        grTxtSaveFilename = gr.Textbox.update(value=file_metadata.split("|", 1)[0])
                         grHtmlModelName = gr.HTML.update(
                             value=self.Civitai.modelNameTitleHtml(
                                 self.Civitai.getSelectedModelName(),
@@ -983,17 +984,18 @@ class Components():
                 outputs=[])
 
             def updateDlUrl(grDrpdwnSelectFile):
+                selection = '' if grDrpdwnSelectFile is None else grDrpdwnSelectFile
                 return (
                     gr.Textbox.update(
-                        value=self.Civitai.getUrlByName(grDrpdwnSelectFile)
+                        value=self.Civitai.getUrlByNameMetadata(selection)
                     ),
                     gr.Textbox.update(
-                        value=self.Civitai.getHashByName(grDrpdwnSelectFile)
+                        value=self.Civitai.getHashByNameMetadata(selection)
                     ),
-                    gr.Button.update(interactive=True if grDrpdwnSelectFile else False),
-                    gr.Button.update(interactive=True if grDrpdwnSelectFile else False),
+                    gr.Button.update(interactive=True if selection else False), # '' is evaluated as False
+                    gr.Button.update(interactive=True if selection else False),
                     gr.Textbox.update(value=""),
-                    gr.Textbox.update(value=grDrpdwnSelectFile),
+                    gr.Textbox.update(value=selection.split("|", 1)[0]),
                 )
 
             def checkEarlyAccess(grTxtEarlyAccess):
@@ -1194,7 +1196,7 @@ class Components():
                             grTxtCreator,
                         ) = update_model_info(grRadioVersions["value"], grChkbxgrpLevel)
                         # grTxtDlUrl = gr.Textbox.update(value=self.Civitai.getUrlByName(grDrpdwnSelectFile['value']))
-                        grTxtHash = gr.Textbox.update(value=self.Civitai.getHashByName(grDrpdwnSelectFile['value']))
+                        grTxtHash = gr.Textbox.update(value=self.Civitai.getHashByNameMetadata(grDrpdwnSelectFile['value']))
                         grTxtVersionInfo = gr.Textbox.update(
                             value=json.dumps(self.Civitai.modelVersionsInfo())
                         )

--- a/scripts/civsfz_ui.py
+++ b/scripts/civsfz_ui.py
@@ -948,6 +948,7 @@ class Components():
                         gr.Textbox.update(value=None),
                         gr.Textbox.update(value=None),
                         gr.HTML.update(value=None),
+                        gr.Textbox.update(value=None),
                     )
             grRadioVersions.change(
                 fn=update_model_info,


### PR DESCRIPTION
- Improves the File Select listing by showing the related metadata in the dropdown. For example:
```
file1.safetensors | SafeTensor | pruned | fp8
file2.safetensors | SafeTensor | full | fp8
file3.safetensors | SafeTensor | pruned | bf16
file4.safetensors | SafeTensor | full | bf16
```

This also fixes the inability to select a file if all of the files were given the exact same name.

I also fixed a couple bugs in the `update_model_info` function.